### PR TITLE
修复 unit.lua 的错误. 添加两个api

### DIFF
--- a/object/editable_object/ability.lua
+++ b/object/editable_object/ability.lua
@@ -483,4 +483,10 @@ function M.get_skill_type_pointer(name)
     return GameAPI.get_ability_key_skill_pointer(name)
 end
 
+---设置技能最大CD
+---@param value number
+function M:set_max_cd(value)
+    return self:set_float_attr("cold_down_time", value)
+end
+
 return M

--- a/object/editable_object/unit.lua
+++ b/object/editable_object/unit.lua
@@ -106,7 +106,7 @@ function M:shift_item(item, type, index, force)
     self.handle:api_shift_item_new(item.handle, type, index, force)
 end
 
----获取指定类型的搜友技能
+---获取指定类型的所有技能
 ---@param type y3.Const.AbilityType
 ---@return Ability[]
 function M:get_abilities_by_type(type)
@@ -518,7 +518,7 @@ end
 ---@param attr_name string 属性名
 ---@param value number 属性值
 ---@param attr_type string 属性类型
-function M:set_attr(attr_type, attr_name, value)
+function M:set_attr(attr_name, value, attr_type)
     self.handle:api_set_attr_by_attr_element(attr_name, Fix32(value), attr_type)
 end
 
@@ -526,7 +526,7 @@ end
 ---@param attr_name string 属性名
 ---@param value number 属性值
 ---@param attr_type string 属性类型
-function M:add_attr(attr_type, attr_name, value)
+function M:add_attr(attr_name, value, attr_type)
     self.handle:api_add_attr_by_attr_element(attr_name, Fix32(value), attr_type)
 end
 
@@ -1635,6 +1635,12 @@ function M:damage(data)
         data.socket or '',
         data.text_type or 'physics'
     )
+end
+
+---获取单位主属性(需要开启复合属性)
+---@return string
+function M:get_main_attr()
+    return self.handle:api_get_main_attr()
 end
 
 return M


### PR DESCRIPTION
同时修复了 `unit.lua` 的 `set_attr` 与 `add_attr`方法的参数与注释顺序不一致