### PR TITLE
ability:kv_load() 支持 'UnitName' 类型

### DIFF
--- a/game/kv.lua
+++ b/game/kv.lua
@@ -19,7 +19,7 @@ local class = require 'y3.tools.class'
 ---@enum(key) KV.SupportTypeEnum
 local apiAlias = {
     Unit         = 'unit_entity',
-    UnitName     = 'unit_name',
+    UnitKey      = 'unit_name',
     Ability      = 'ability',
     Item         = 'item_entity',
     Buff         = 'modifier_entity',

--- a/game/kv.lua
+++ b/game/kv.lua
@@ -19,6 +19,7 @@ local class = require 'y3.tools.class'
 ---@enum(key) KV.SupportTypeEnum
 local apiAlias = {
     Unit         = 'unit_entity',
+    UnitName     = 'unit_name',
     Ability      = 'ability',
     Item         = 'item_entity',
     Buff         = 'modifier_entity',


### PR DESCRIPTION
如图所示物体编辑器中的一个技能自定义数据：
![image](https://github.com/y3-editor/y3-lualib/assets/10196693/122d45e8-9c86-48ce-8a77-5caf7151ec4f)
想要在 lua 这边获取其字段目前没找到合适的方法，尝试增加 'UnitName' 类型，这样可以像这样获取自定义单位 Id：
``` lua
-- 建造章鱼哥
local M = y3.object.ability[134258316]

function M.on_cast_shot(ability, cast)
    local Owner = ability:get_owner()
    local MonsterType = ability:kv_load('建造单位', 'UnitName')
    -- local MonsterType = ability:kv_load('建造单位', 'Unit') # 这种写法会报错
    Owner:create_unit(MonsterType, Owner:get_point(), 0)
end

return M
```