### PR TITLE
Update particle.lua

### DIFF
--- a/object/runtime_object/particle.lua
+++ b/object/runtime_object/particle.lua
@@ -62,7 +62,7 @@ end
 ---@field socket? string 特效挂节点，只有当 `target` 的类型为单位时有效
 ---@field follow_rotation? integer | y3.Const.SfxRotateType 跟随单位旋转的模式，只有当 `target` 的类型为单位时有效
 ---@field follow_scale? boolean 是否跟随单位缩放，只有当 `target` 的类型为单位时有效
----@field immediate? boolean 销毁时，是否有过度
+---@field immediate? boolean 销毁时，是否立刻移除显示效果
 
 --创建特效到单位或点
 ---@param data Particle.Param.Create


### PR DESCRIPTION
注释有误解性，实际为真的时候是立刻移除显示效果，而不是为真的时候有过度。