### PR TITLE
refactor: UI 框架改用 share 模块 + 导出公开 API (y3.ui_manager)

### DIFF
--- a/ui_framework/api.lua
+++ b/ui_framework/api.lua
@@ -1,0 +1,210 @@
+--[[
+    UI 管理器公开 API
+
+    通过 y3.ui_manager 访问，提供界面注册、控制、事件等功能。
+    用户不需要修改 lualib 内部文件，全部通过 API 操作。
+
+    使用示例：
+    ```lua
+    -- 注册界面
+    y3.ui_manager.register_popup("ShopDialog", "xxxxxxxx-xxxx-xxxx")
+    y3.ui_manager.register_hud("MainHUD", "yyyyyyyy-yyyy-yyyy")
+    y3.ui_manager.register_tips("SmallTips", "zzzzzzzz-zzzz-zzzz")
+
+    -- 控制界面
+    y3.ui_manager.open("ShopDialog")
+    y3.ui_manager.close("ShopDialog")
+
+    -- 事件总线
+    y3.ui_manager.on("gold_change", function(data) ... end)
+    y3.ui_manager.emit("gold_change", { gold = 100 })
+    ```
+]]
+
+local share = require 'y3.ui_framework.share'
+local UIConst = require 'y3.ui_framework.UIConst'
+
+---@class y3.UIManagerAPI
+local API = {}
+
+----------------------------
+-- 界面注册
+----------------------------
+
+---注册弹窗界面（可被 ESC 关闭，支持互斥）
+---@param name string 界面名（需与 Class 名一致）
+---@param uuid string 界面 UUID（从编辑器复制）
+function API.register_popup(name, uuid)
+    UIConst.Popup[name] = name
+    UIConst.UUID[name] = uuid
+end
+
+---注册常驻 HUD 界面
+---@param name string 界面名
+---@param uuid string 界面 UUID
+function API.register_hud(name, uuid)
+    UIConst.Hud[name] = name
+    UIConst.UUID[name] = uuid
+end
+
+---注册菜单界面
+---@param name string 界面名
+---@param uuid string 界面 UUID
+function API.register_menu(name, uuid)
+    UIConst.Menu[name] = name
+    UIConst.UUID[name] = uuid
+end
+
+---注册 Tips 界面
+---@param name string 界面名
+---@param uuid string 界面 UUID
+function API.register_tips(name, uuid)
+    UIConst.Tips[name] = name
+    UIConst.UUID[name] = uuid
+end
+
+---配置互斥组（同组内同时只能显示一个）
+---@param group_name string 组名
+---@param ui_names string[] 界面名列表
+function API.set_mutual(group_name, ui_names)
+    UIConst.Mutual[group_name] = ui_names
+end
+
+---配置不响应 ESC 关闭的界面
+---@param names string[] 界面名列表
+function API.set_no_esc(names)
+    UIConst.NoEsc = names
+end
+
+----------------------------
+-- 界面控制
+----------------------------
+
+---打开界面
+---@param name string 界面名
+---@param ... any 传递给 on_refresh 的参数
+function API.open(name, ...)
+    share.uiMgr:openUI(name, ...)
+end
+
+---关闭界面
+---@param name string 界面名
+function API.close(name)
+    share.uiMgr:closeUI(name)
+end
+
+---关闭栈顶弹窗（ESC 响应）
+function API.close_top()
+    share.uiMgr:closeTopUI()
+end
+
+---关闭所有弹窗
+---@param except? string 排除的界面名
+function API.close_all_popup(except)
+    share.uiMgr:closeAllPopup(except)
+end
+
+---判断界面是否打开
+---@param name string 界面名
+---@return boolean
+function API.is_open(name)
+    return share.uiMgr:isUIOpen(name)
+end
+
+---判断是否有弹窗打开
+---@return boolean
+function API.has_popup()
+    return share.uiMgr:isExistUIOpen()
+end
+
+---获取界面控制器（BasePanel 实例）
+---@param name string 界面名
+---@return BasePanel|nil
+function API.get_ctrl(name)
+    return share.uiMgr:getUICtrl(name)
+end
+
+---获取视图控制器（BaseView 实例）
+---@param name string 界面名
+---@return BaseView|nil
+function API.get_view_ctrl(name)
+    return share.uiMgr:getUIViewCtrl(name)
+end
+
+----------------------------
+-- Tips 控制
+----------------------------
+
+---显示 Tips
+---@param name string Tips 名称
+---@param param? table 参数
+function API.show_tips(name, param)
+    share.uiMgr:showTips(name, param)
+end
+
+---隐藏 Tips
+---@param name string Tips 名称
+---@param param? table 参数
+function API.hide_tips(name, param)
+    share.uiMgr:hideTips(name, param)
+end
+
+----------------------------
+-- 事件总线
+----------------------------
+
+---订阅事件
+---@param event string 事件名
+---@param callback function 回调函数
+---@return function unsubscribe 取消订阅函数
+function API.on(event, callback)
+    return share.event:on(event, callback)
+end
+
+---一次性订阅（触发一次后自动取消）
+---@param event string 事件名
+---@param callback function 回调函数
+---@return function unsubscribe 取消订阅函数
+function API.once(event, callback)
+    return share.event:once(event, callback)
+end
+
+---取消订阅
+---@param event string 事件名
+---@param callback function 回调函数
+function API.off(event, callback)
+    share.event:off(event, callback)
+end
+
+---发布事件
+---@param event string 事件名
+---@param ... any 参数
+function API.emit(event, ...)
+    share.event:emit(event, ...)
+end
+
+---清空某事件的所有监听
+---@param event string 事件名
+function API.clear_event(event)
+    share.event:clear(event)
+end
+
+----------------------------
+-- 防连点锁定
+----------------------------
+
+---自动锁定（防连点）
+---@param key string 锁定标识
+---@param strength? number 锁定强度 1/2/3
+function API.auto_lock(key, strength)
+    share.uiMgr:autoLock(key, strength)
+end
+
+---判断是否锁定
+---@param key string 锁定标识
+---@return boolean
+function API.is_locked(key)
+    return share.uiMgr:islock(key)
+end
+
+return API

--- a/ui_framework/base/BasePanel.lua
+++ b/ui_framework/base/BasePanel.lua
@@ -7,6 +7,7 @@
 ---@field _isAttached boolean 是否已完成 attach
 ---@field _eventHandlers table<string, function[]> 面板内部事件监听器
 ---@field _eventBusUnsubscribes function[] 全局事件总线的取消订阅函数列表
+---@field __class_events? table[] 类级别事件注册（由 on_event 写入）
 ---@field _gcHost GCHost 生命周期垃圾回收宿主
 local M = Class "BasePanel"
 

--- a/ui_framework/base/BasePanel.lua
+++ b/ui_framework/base/BasePanel.lua
@@ -5,9 +5,12 @@
 ---@field _localPlayerId integer 本地玩家ID
 ---@field _name string 界面名称
 ---@field _isAttached boolean 是否已完成 attach
----@field _eventHandlers table<string, function[]> 事件监听器
+---@field _eventHandlers table<string, function[]> 面板内部事件监听器
+---@field _eventBusUnsubscribes function[] 全局事件总线的取消订阅函数列表
 ---@field _gcHost GCHost 生命周期垃圾回收宿主
 local M = Class "BasePanel"
+
+local share = require 'y3.ui_framework.share'
 
 ---@return self
 function M:__init()
@@ -15,6 +18,7 @@ function M:__init()
     self._controls = {}
     self._isAttached = false
     self._eventHandlers = {}
+    self._eventBusUnsubscribes = {}
     self._localPlayerId = nil
     self._localPlayer = nil
     self._gcHost = New "GCHost" ()
@@ -104,6 +108,29 @@ function M:on_hide(...) end
 ---子类重写：销毁时调用
 function M:on_destroy() end
 
+---注册全局事件总线监听（类级别，与 on_init 平行定义）
+---在 attach 时自动绑定到事件总线，destroy 时自动清理
+---callback 的第一个参数是面板实例 self
+---
+---用法：
+---```lua
+---Panel2:on_event("gold_change", function(self, data)
+---    log.info("金币变化: " .. data.gold)
+---end)
+---```
+---@param eventName string 事件名
+---@param callback fun(self: BasePanel, ...) 回调函数，第一个参数为面板实例
+function M:on_event(eventName, callback)
+    -- 类级别调用：存储到类表上，attach 时自动注册
+    if not rawget(self, '__class_events') then
+        rawset(self, '__class_events', {})
+    end
+    table.insert(rawget(self, '__class_events'), {
+        event = eventName,
+        callback = callback,
+    })
+end
+
 ----------------------------
 -- 内部生命周期方法（由 UIManager 调用）
 ----------------------------
@@ -119,6 +146,7 @@ function M:attach(ui)
     -- 防御性初始化：确保关键字段存在
     self._controls = self._controls or {}
     self._eventHandlers = self._eventHandlers or {}
+    self._eventBusUnsubscribes = self._eventBusUnsubscribes or {}
     self._gcHost = self._gcHost or New "GCHost" ()
 
     -- 支持传入 UUID 字符串
@@ -142,6 +170,18 @@ function M:attach(ui)
     end
 
     local localPlayer = self:getLocalPlayer()
+
+    -- 注册类级别的事件监听（通过 on_event 定义的）
+    local classEvents = self.__class_events
+    if classEvents then
+        for _, handler in ipairs(classEvents) do
+            local cb = handler.callback
+            local unsubscribe = share.event:on(handler.event, function(...)
+                cb(self, ...)  -- 传入实例作为第一个参数
+            end)
+            table.insert(self._eventBusUnsubscribes, unsubscribe)
+        end
+    end
 
     -- 调用子类 on_init
     self:on_init(ui, localPlayer)
@@ -180,8 +220,16 @@ function M:destroy()
     -- 调用子类 on_destroy
     self:on_destroy()
 
-    -- 清理事件
+    -- 清理面板内部事件
     self._eventHandlers = {}
+
+    -- 清理全局事件总线的订阅
+    if self._eventBusUnsubscribes then
+        for _, unsubscribe in ipairs(self._eventBusUnsubscribes) do
+            unsubscribe()
+        end
+        self._eventBusUnsubscribes = {}
+    end
 
     -- 销毁 GCHost（自动清理绑定的所有资源）
     if self._gcHost then

--- a/ui_framework/init.lua
+++ b/ui_framework/init.lua
@@ -54,4 +54,7 @@ y3.game:event('游戏-初始化', function(trg, data)
     log.info("[UI Framework] UIManager 启动完成")
 end)
 
+-- 导出公开 API 到 y3.ui_manager
+y3.ui_manager = require 'y3.ui_framework.api'
+
 log.info("[UI Framework] UI 框架加载完成")

--- a/ui_framework/share.lua
+++ b/ui_framework/share.lua
@@ -1,15 +1,8 @@
 --[[
-    UI 框架共享状态
+    UI 框架共享状态（内部模块）
 
-    所有需要访问 event / uiMgr 的模块通过 require 此文件获取。
-    避免使用全局变量，保持模块间解耦。
-
-    使用方法：
-    ```lua
-    local share = require 'y3.ui_framework.share'
-    share.uiMgr:openUI("MyPanel")
-    share.event:emit("data_change", data)
-    ```
+    框架内部模块通过 require 此文件共享 event 和 uiMgr 实例。
+    用户不应直接 require 此文件，请使用 y3.ui_manager API。
 ]]
 
 ---@class UIFrameworkShare


### PR DESCRIPTION
基于 #644 的反馈进行重构：

移除全局 GamePlay 表 — 改用内部 share.lua 模块管理共享状态，不污染全局命名空间
导出公开 API — 新增 api.lua，挂载到 y3.ui_manager，用户通过 API 注册和控制界面，无需修改 lualib 内部文件
新增 on_event 类级别事件注册 — 与 on_init 平行定义，attach 时自动绑定，destroy 时自动清理
用户使用方式：
y3.ui_manager.register_popup("ShopDialog", "uuid")
y3.ui_manager.open("ShopDialog")
y3.ui_manager.emit("gold_change", { gold = 100 })