### PR TITLE
Fix BasePanel bindClick callback registration

### DIFF
--- a/ui_framework/base/BasePanel.lua
+++ b/ui_framework/base/BasePanel.lua
@@ -292,8 +292,7 @@ function M:bindClick(control, callback)
         return
     end
 
-    ---@diagnostic disable-next-line: param-type-mismatch
-    local trigger = control:add_event("左键-点击", function(trg, data)
+    local trigger = control:add_fast_event("左键-点击", function(trg, data)
         if callback then
             callback()
         end


### PR DESCRIPTION
﻿## Summary
- Fix `BasePanel:bindClick` so it registers Lua callbacks through `UI:add_fast_event`
- Align click binding with existing `bindPress` / `bindRelease` helper behavior

## Cause
`UI:add_event(event, name, data)` creates a named UI event and does not accept a Lua callback as its second argument. `bindClick` passed the callback there, so the click callback was never subscribed. `bindRelease` worked because it already used `add_fast_event`.

## Verification
- Ran `git diff --check`
- Manual local observation before fix: `bindRelease` fired on `setting_btn`, while `bindClick` did not

## Not tested
- Y3 runtime click event after fix in the client
- Lua syntax check, because `lua` executable is unavailable in this environment
