### PR TITLE
refactor: request_open_archive 改为模块级函数，支持指定 AID 查询离线存档

### DIFF
--- a/object/runtime_object/player.lua
+++ b/object/runtime_object/player.lua
@@ -1,4 +1,4 @@
---玩家
+﻿--玩家
 ---@class Player
 ---@field handle py.Role
 ---@field id integer
@@ -886,11 +886,12 @@ function M:request_random_number(group_id, key, callback)
     end, {})
 end
 
----请求玩家的开放存档数据
+---请求玩家的离线存档数据
+---@param aid string|integer # 目标玩家的平台AID
 ---@param callback fun(archive: any) # 执行完毕后的回调函数
-function M:request_open_archive(callback)
+function M.request_open_archive(aid, callback)
     ---@diagnostic disable-next-line: undefined-field
-    GameAPI.lua_request_role_open_archive(self.handle, function (context)
+    GameAPI.lua_request_role_open_archive(tostring(aid), function (context)
         xpcall(callback, log.error, context['__role_open_archive'])
     end, {})
 end


### PR DESCRIPTION
将 player:request_open_archive() 从实例方法改为模块级函数
y3.player.request_open_archive(aid, callback)，不再依赖 self.handle， 调用方始终显式传入目标平台 AID（字符串类型），内部做 tostring 保护。

Constraint: 原始实现仅支持查自身(self.handle)，无法查任意 AID
Confidence: high
Scope-risk: narrow
Tested: maptest自测环境验证通过